### PR TITLE
Enable direct server startup via python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ ENV HF_HOME=/models \
 
 VOLUME ["/models"]
 
-CMD ["voxcpm-api", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python3", "-m", "voxcpm.server.app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -145,7 +145,13 @@ VoxCPM now ships with an OpenAI-compatible Text-to-Speech API server featuring G
 
 ```bash
 pip install -e .
-voxcpm-api --host 0.0.0.0 --port 8000
+python -m voxcpm.server.app --host 0.0.0.0 --port 8000
+```
+
+Running the module adds the project root to ``PYTHONPATH``, so you can also execute the server directly from the source tree:
+
+```bash
+python src/voxcpm/server/app.py --host 0.0.0.0 --port 8000
 ```
 
 The server exposes endpoints that mirror the OpenAI Audio API:

--- a/src/voxcpm/server/app.py
+++ b/src/voxcpm/server/app.py
@@ -13,11 +13,25 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
-from .audio import AudioEncoder, apply_speed
-from .config import ServerSettings
-from .schemas import AudioSpeechRequest
-from .tts import VoxCPMTTSManager
-from .voices import VoiceLibrary
+if __package__ in {None, ""}:  # pragma: no cover - runtime convenience
+    import pathlib
+    import sys
+
+    package_root = pathlib.Path(__file__).resolve().parents[2]
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+
+    from voxcpm.server.audio import AudioEncoder, apply_speed  # type: ignore[import-not-found]
+    from voxcpm.server.config import ServerSettings  # type: ignore[import-not-found]
+    from voxcpm.server.schemas import AudioSpeechRequest  # type: ignore[import-not-found]
+    from voxcpm.server.tts import VoxCPMTTSManager  # type: ignore[import-not-found]
+    from voxcpm.server.voices import VoiceLibrary  # type: ignore[import-not-found]
+else:  # pragma: no cover - exercised via package imports
+    from .audio import AudioEncoder, apply_speed
+    from .config import ServerSettings
+    from .schemas import AudioSpeechRequest
+    from .tts import VoxCPMTTSManager
+    from .voices import VoiceLibrary
 
 LOGGER = logging.getLogger("voxcpm.server.app")
 
@@ -201,4 +215,20 @@ def _encode_sse(event: str, data: Dict[str, Any]) -> bytes:
     return f"event: {event}\ndata: {message}\n\n".encode("utf-8")
 
 
-__all__ = ["create_app"]
+def main() -> None:  # pragma: no cover - CLI shim
+    """Entry-point for running the server directly via ``python app.py``."""
+
+    if __package__ in {None, ""}:  # pragma: no cover - runtime convenience
+        # ``voxcpm.server.main`` relies on the same path bootstrap performed above.
+        from voxcpm.server.main import run as _run  # type: ignore[import-not-found]
+    else:  # pragma: no cover - exercised via package imports
+        from .main import run as _run
+
+    _run()
+
+
+if __name__ == "__main__":  # pragma: no cover - runtime convenience
+    main()
+
+
+__all__ = ["create_app", "main"]

--- a/src/voxcpm/server/main.py
+++ b/src/voxcpm/server/main.py
@@ -7,8 +7,19 @@ from typing import Any, Dict
 
 import uvicorn
 
-from .app import create_app
-from .config import ServerSettings
+if __package__ in {None, ""}:  # pragma: no cover - runtime convenience
+    import pathlib
+    import sys
+
+    package_root = pathlib.Path(__file__).resolve().parents[2]
+    if str(package_root) not in sys.path:
+        sys.path.insert(0, str(package_root))
+
+    from voxcpm.server.app import create_app  # type: ignore[import-not-found]
+    from voxcpm.server.config import ServerSettings  # type: ignore[import-not-found]
+else:  # pragma: no cover - exercised via package imports
+    from .app import create_app
+    from .config import ServerSettings
 
 
 def build_argument_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
## Summary
- allow `voxcpm.server.app` and `voxcpm.server.main` to bootstrap the source tree onto `sys.path` so they can be executed directly with `python`
- add a CLI shim in `voxcpm.server.app` and update the Docker image to start the server via `python -m voxcpm.server.app`
- document the new invocation method for local runs, including direct execution from the repository

## Testing
- PYTHONPATH=src python -m voxcpm.server.main --help
- python src/voxcpm/server/app.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d02a2ea0d0832bbd0ae23242ef0178