### PR TITLE
Improve audio speech API options and voice discovery

### DIFF
--- a/src/voxcpm/server/config.py
+++ b/src/voxcpm/server/config.py
@@ -5,16 +5,19 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, List, Optional
 
 
 def _default_voices_dir() -> Path:
-    """Return the bundled voices directory shipped with the package."""
+    """Return the directory that should be used for bundled/custom voices."""
 
+    package_root = Path(__file__).resolve().parents[3]
     candidates = [
-        Path(__file__).resolve().parents[3] / "assets" / "voices",
-        Path(__file__).resolve().parent / "voices",
+        package_root / "voices",
+        package_root / "assets" / "voices",
+        Path.cwd() / "voices",
         Path.cwd() / "assets" / "voices",
+        Path(__file__).resolve().parent / "voices",
     ]
     for path in candidates:
         if path.exists():
@@ -42,6 +45,18 @@ def _coerce_float(value: Optional[object], default: float) -> float:
     return float(value)
 
 
+def _coerce_str_list(value: Optional[object], default: Iterable[str]) -> List[str]:
+    if value is None:
+        return list(default)
+    if isinstance(value, str):
+        if not value.strip():
+            return []
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, Iterable):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
 def _coerce_path(value: Optional[str]) -> Optional[str]:
     if not value:
         return None
@@ -66,6 +81,11 @@ class ServerSettings:
 
     stream_chunk_size: int
     allow_streaming: bool
+
+    cors_allow_origins: List[str]
+    cors_allow_methods: List[str]
+    cors_allow_headers: List[str]
+    cors_allow_credentials: bool
 
     inference_cfg_value: float
     inference_timesteps: int
@@ -107,6 +127,19 @@ class ServerSettings:
             overrides.get("stream_chunk_size") or env.get("VOXCPM_STREAM_CHUNK_SIZE"), 32768
         )
         self.allow_streaming = _coerce_bool(overrides.get("allow_streaming") or env.get("VOXCPM_ALLOW_STREAMING"), True)
+
+        self.cors_allow_origins = _coerce_str_list(
+            overrides.get("cors_allow_origins") or env.get("VOXCPM_CORS_ALLOW_ORIGINS"), ["*"]
+        )
+        self.cors_allow_methods = _coerce_str_list(
+            overrides.get("cors_allow_methods") or env.get("VOXCPM_CORS_ALLOW_METHODS"), ["GET", "POST", "OPTIONS"]
+        )
+        self.cors_allow_headers = _coerce_str_list(
+            overrides.get("cors_allow_headers") or env.get("VOXCPM_CORS_ALLOW_HEADERS"), ["*"]
+        )
+        self.cors_allow_credentials = _coerce_bool(
+            overrides.get("cors_allow_credentials") or env.get("VOXCPM_CORS_ALLOW_CREDENTIALS"), False
+        )
 
         self.inference_cfg_value = _coerce_float(overrides.get("inference_cfg_value") or env.get("VOXCPM_CFG_VALUE"), 2.0)
         self.inference_timesteps = _coerce_int(

--- a/src/voxcpm/server/schemas.py
+++ b/src/voxcpm/server/schemas.py
@@ -33,7 +33,7 @@ class PromptOverride(BaseModel):
 class AudioSpeechRequest(BaseModel):
     """Schema for the OpenAI-compatible ``/v1/audio/speech`` endpoint."""
 
-    model: str
+    model: Optional[str] = Field(None, description="Model identifier")
     voice: Optional[str] = Field(None, description="Voice preset identifier")
     input: str = Field(..., description="Text to synthesize")
     response_format: str = Field("mp3", alias="response_format")

--- a/src/voxcpm/server/tts.py
+++ b/src/voxcpm/server/tts.py
@@ -110,7 +110,11 @@ class VoxCPMTTSManager:
                 prompt_text = prompt_override.text
 
         if prompt_path and not prompt_text:
-            raise ValueError("A prompt_text must be provided when prompt audio is supplied")
+            raise ValueError(
+                "Voice '{name}' requires a transcript. Provide a '{name}.txt' file next to the prompt audio "
+                "or include prompt.text in the request payload."
+                .format(name=voice.name)
+            )
 
         cfg_value = cfg_scale if cfg_scale is not None else self.settings.inference_cfg_value
         inference_timesteps = inference_steps if inference_steps is not None else self.settings.inference_timesteps

--- a/src/voxcpm/server/voices.py
+++ b/src/voxcpm/server/voices.py
@@ -1,13 +1,16 @@
-"""Voice library utilities."""
+"""Voice preset discovery utilities for the VoxCPM API server."""
 
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from pydantic import BaseModel, ValidationError
+
+LOGGER = logging.getLogger("voxcpm.server.voices")
 
 
 class VoiceConfig(BaseModel):
@@ -17,6 +20,7 @@ class VoiceConfig(BaseModel):
     description: Optional[str] = None
     prompt_audio: Optional[str] = None
     prompt_text: Optional[str] = None
+    transcript_file: Optional[str] = None
     language: Optional[str] = None
     tags: Optional[List[str]] = None
 
@@ -32,16 +36,50 @@ class VoiceProfile:
     language: Optional[str] = None
     tags: List[str] = field(default_factory=list)
 
-    def to_response(self) -> Dict[str, Optional[str]]:
+    def to_response(self) -> Dict[str, object]:
         """Serialize the profile for API responses."""
 
         return {
             "name": self.name,
             "description": self.description,
             "language": self.language,
-            "tags": self.tags,
-            "has_prompt": self.prompt_audio is not None,
+            "tags": list(self.tags),
+            "has_prompt_audio": self.prompt_audio is not None,
+            "has_prompt_text": bool(self.prompt_text),
         }
+
+
+def _resolve_path(base_dir: Path, value: Optional[str], *, label: str) -> Optional[Path]:
+    """Resolve ``value`` relative to ``base_dir`` and ensure it exists."""
+
+    if not value:
+        return None
+
+    candidate = Path(value).expanduser()
+    if not candidate.is_absolute():
+        candidate = (base_dir / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+
+    if not candidate.exists():
+        LOGGER.warning("%s '%s' defined under %s does not exist", label, candidate, base_dir)
+        return None
+    return candidate
+
+
+def _read_transcript_file(path: Path, *, warn_if_missing: bool) -> Optional[str]:
+    """Return cleaned transcript text from ``path`` if available."""
+
+    if not path.exists():
+        if warn_if_missing:
+            LOGGER.warning("Transcript file '%s' could not be found", path)
+        return None
+    try:
+        contents = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        LOGGER.warning("Failed to read transcript file '%s': %s", path, exc)
+        return None
+    return contents or None
 
 
 class VoiceLibrary:
@@ -56,6 +94,8 @@ class VoiceLibrary:
         """Reload voice definitions from disk."""
 
         voices: Dict[str, VoiceProfile] = {}
+        metadata: Dict[str, Tuple[VoiceConfig, Path]] = {}
+
         if self.directory.exists():
             for json_file in sorted(self.directory.glob("*.json")):
                 try:
@@ -63,25 +103,70 @@ class VoiceLibrary:
                         data = json.load(handle)
                     config = VoiceConfig(**data)
                 except (OSError, json.JSONDecodeError, ValidationError) as exc:
-                    # Skip malformed definitions while preserving others.
-                    print(f"[VoiceLibrary] Failed to load {json_file}: {exc}")
+                    LOGGER.warning("Failed to load voice definition '%s': %s", json_file, exc)
                     continue
 
-                prompt_audio_path: Optional[Path] = None
-                if config.prompt_audio:
-                    prompt_audio_path = (json_file.parent / config.prompt_audio).resolve()
+                metadata[config.name.lower()] = (config, json_file.parent)
+
+            wav_files = sorted({path for pattern in ("*.wav", "*.WAV") for path in self.directory.glob(pattern)})
+            for wav_file in wav_files:
+                voice_key = wav_file.stem.lower()
+                config_entry = metadata.pop(voice_key, None)
+                config = config_entry[0] if config_entry else None
+                base_dir = config_entry[1] if config_entry else wav_file.parent
+
+                transcript_text: Optional[str] = None
+                if config:
+                    if config.prompt_text:
+                        transcript_text = config.prompt_text.strip() or None
+                    elif config.transcript_file:
+                        transcript_path = _resolve_path(base_dir, config.transcript_file, label="Transcript file")
+                        if transcript_path:
+                            transcript_text = _read_transcript_file(transcript_path, warn_if_missing=True)
+                if transcript_text is None:
+                    transcript_candidate = wav_file.with_suffix(".txt")
+                    transcript_text = _read_transcript_file(transcript_candidate, warn_if_missing=False)
+
+                name = wav_file.stem
+                if config and config.name.lower() != voice_key:
+                    LOGGER.info(
+                        "Voice definition '%s' overrides name to '%s'; using filename '%s' instead",
+                        wav_file.name,
+                        config.name,
+                        name,
+                    )
+                description = config.description if config else f"Voice derived from {wav_file.name}"
+                language = config.language if config else None
+                tags = list(config.tags or []) if config else []
 
                 profile = VoiceProfile(
-                    name=config.name,
-                    description=config.description,
-                    prompt_audio=prompt_audio_path,
-                    prompt_text=config.prompt_text,
-                    language=config.language,
-                    tags=config.tags or [],
+                    name=name,
+                    description=description,
+                    prompt_audio=wav_file.resolve(),
+                    prompt_text=transcript_text,
+                    language=language,
+                    tags=tags,
                 )
-                voices[config.name.lower()] = profile
+                voices[name.lower()] = profile
 
-        # Always ensure the default voice is available.
+        for voice_key, (config, base_dir) in metadata.items():
+            prompt_audio_path = _resolve_path(base_dir, config.prompt_audio, label="Prompt audio")
+            transcript_text = config.prompt_text.strip() if config.prompt_text else None
+            if not transcript_text and config.transcript_file:
+                transcript_path = _resolve_path(base_dir, config.transcript_file, label="Transcript file")
+                if transcript_path:
+                    transcript_text = _read_transcript_file(transcript_path, warn_if_missing=True)
+
+            profile = VoiceProfile(
+                name=config.name,
+                description=config.description,
+                prompt_audio=prompt_audio_path,
+                prompt_text=transcript_text,
+                language=config.language,
+                tags=list(config.tags or []),
+            )
+            voices[voice_key] = profile
+
         if "default" not in voices:
             voices["default"] = VoiceProfile(name="default", description="Unconditioned VoxCPM voice")
 
@@ -100,7 +185,7 @@ class VoiceLibrary:
     def list_profiles(self) -> Iterable[VoiceProfile]:  # pragma: no cover - trivial
         return self._voices.values()
 
-    def as_response(self) -> Dict[str, List[Dict[str, Optional[str]]]]:
+    def as_response(self) -> Dict[str, List[Dict[str, object]]]:
         """Return a serializable structure with all voices."""
 
         return {


### PR DESCRIPTION
## Summary
- add CORS middleware, improved validation errors, and OPTIONS support for the /v1/audio/speech endpoint
- autodiscover voice presets from wav files with optional transcripts and metadata overrides
- document the new voice workflow and CORS configuration in the README

## Testing
- python -m compileall src/voxcpm/server

------
https://chatgpt.com/codex/tasks/task_e_68d0355c7be8832b8f1b7f769f7a98f8