### PR TITLE
Normalize voice lookups for OpenAI API

### DIFF
--- a/src/voxcpm/server/app.py
+++ b/src/voxcpm/server/app.py
@@ -163,7 +163,11 @@ def create_app(settings: Optional[ServerSettings] = None) -> FastAPI:
         if model_name not in {settings.openai_model_name, settings.model_id}:
             raise HTTPException(status_code=404, detail=f"Model '{model_name}' is not available")
 
-        voice_name = payload.voice or settings.default_voice
+        raw_voice_name = payload.voice or settings.default_voice
+        voice_name = raw_voice_name.strip()
+        if not voice_name:
+            voice_name = settings.default_voice
+
         voice = voice_library.get(voice_name)
         if voice is None:
             raise HTTPException(status_code=404, detail=f"Voice '{voice_name}' not found")


### PR DESCRIPTION
## Summary
- strip and fall back to the default voice when the request supplies an empty or whitespace-only voice name
- normalize stored voice keys and add relaxed aliases so lookups tolerate whitespace, dashes, and underscores

## Testing
- python -m compileall src/voxcpm/server/voices.py src/voxcpm/server/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d04b0de030832b829882eb266a0f5f