### PR TITLE
Enable automatic prompt transcription for voice presets

### DIFF
--- a/src/voxcpm/server/config.py
+++ b/src/voxcpm/server/config.py
@@ -78,6 +78,10 @@ class ServerSettings:
     retry_badcase_max_times: int
     retry_badcase_ratio_threshold: float
 
+    enable_prompt_asr: bool
+    prompt_asr_model_id: str
+    prompt_asr_device: Optional[str]
+
     log_level: str
 
     def __init__(self, **overrides: object) -> None:
@@ -124,6 +128,18 @@ class ServerSettings:
         self.retry_badcase_ratio_threshold = _coerce_float(
             overrides.get("retry_badcase_ratio_threshold") or env.get("VOXCPM_RETRY_BADCASE_RATIO"), 6.0
         )
+
+        enable_prompt_asr_value = overrides.get("enable_prompt_asr")
+        if enable_prompt_asr_value is None:
+            enable_prompt_asr_value = env.get("VOXCPM_ENABLE_PROMPT_ASR")
+        self.enable_prompt_asr = _coerce_bool(enable_prompt_asr_value, True)
+        self.prompt_asr_model_id = str(
+            overrides.get("prompt_asr_model_id")
+            or env.get("VOXCPM_PROMPT_ASR_MODEL_ID")
+            or "iic/SenseVoiceSmall"
+        )
+        prompt_asr_device_value = overrides.get("prompt_asr_device") or env.get("VOXCPM_PROMPT_ASR_DEVICE")
+        self.prompt_asr_device = str(prompt_asr_device_value) if prompt_asr_device_value else None
 
         self.log_level = str(overrides.get("log_level") or env.get("VOXCPM_LOG_LEVEL") or "info")
 

--- a/src/voxcpm/server/transcription.py
+++ b/src/voxcpm/server/transcription.py
@@ -1,0 +1,86 @@
+"""Utilities for transcribing prompt audio into text."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from typing import Dict, Optional
+
+import torch
+
+LOGGER = logging.getLogger("voxcpm.server.transcription")
+
+
+class PromptTranscriber:
+    """Lazy-loading ASR helper used to obtain prompt transcripts."""
+
+    def __init__(
+        self,
+        model_id: str = "iic/SenseVoiceSmall",
+        device: Optional[str] = None,
+    ) -> None:
+        self.model_id = model_id
+        self.device = device or ("cuda:0" if torch.cuda.is_available() else "cpu")
+        self._model = None
+        self._model_lock = threading.Lock()
+        self._cache: Dict[str, str] = {}
+        self._cache_lock = asyncio.Lock()
+
+    def _ensure_model(self) -> None:
+        if self._model is not None:
+            return
+        with self._model_lock:
+            if self._model is not None:
+                return
+            LOGGER.info("Loading prompt ASR model '%s' on %s", self.model_id, self.device)
+            from funasr import AutoModel  # Imported lazily to avoid startup cost
+
+            self._model = AutoModel(
+                model=self.model_id,
+                disable_update=True,
+                log_level="WARNING",
+                device=self.device,
+            )
+
+    def _transcribe_sync(self, audio_path: str) -> str:
+        self._ensure_model()
+        if self._model is None:  # pragma: no cover - defensive safety
+            raise RuntimeError("Prompt ASR model failed to initialise")
+
+        result = self._model.generate(input=audio_path, language="auto", use_itn=True)
+        text = ""
+        if result and isinstance(result, list):
+            candidate = result[0].get("text", "") if isinstance(result[0], dict) else str(result[0])
+            text = str(candidate).split("|>")[-1].strip()
+        return text
+
+    async def transcribe(self, audio_path: str) -> str:
+        """Return the transcript for ``audio_path`` (cached per path)."""
+
+        async with self._cache_lock:
+            cached = self._cache.get(audio_path)
+        if cached:
+            return cached
+
+        loop = asyncio.get_running_loop()
+        try:
+            text = await loop.run_in_executor(None, self._transcribe_sync, audio_path)
+        except Exception as exc:  # pragma: no cover - runtime safeguard
+            raise RuntimeError(f"Failed to transcribe prompt audio '{audio_path}': {exc}") from exc
+
+        cleaned = text.strip()
+        if not cleaned:
+            raise RuntimeError(f"Transcription for '{audio_path}' returned empty text")
+
+        async with self._cache_lock:
+            self._cache[audio_path] = cleaned
+        return cleaned
+
+    def clear_cache(self) -> None:  # pragma: no cover - maintenance helper
+        """Clear cached transcripts (mainly for testing)."""
+
+        self._cache.clear()
+
+
+__all__ = ["PromptTranscriber"]

--- a/tests/test_audio_endpoint.py
+++ b/tests/test_audio_endpoint.py
@@ -1,0 +1,86 @@
+import sys
+
+import numpy as np
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+sys.path.append("src")
+
+import voxcpm.server.app as server_app
+from voxcpm.server.config import ServerSettings
+
+
+class DummyTranscriber:
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+        DummyTranscriber.instances.append(self)
+
+    async def transcribe(self, audio_path: str) -> str:
+        self.calls.append(audio_path)
+        return "auto transcript"
+
+
+def _patch_model_loading():
+    def fake_load_model(self):
+        class _DummyModel:
+            def __init__(self):
+                self.tts_model = type("tts", (), {"sample_rate": 16000})()
+
+            def generate(self, **kwargs):
+                return np.zeros(16000, dtype=np.float32)
+
+        self._model = _DummyModel()
+        self._sample_rate = 16000
+
+    return patch("voxcpm.server.tts.VoxCPMTTSManager._load_model", fake_load_model)
+
+
+def test_voice_prompt_auto_transcription(tmp_path):
+    voice_wav = tmp_path / "myvoice.wav"
+    voice_wav.write_bytes(b"fake")
+
+    settings = ServerSettings(voices_dir=str(tmp_path))
+    DummyTranscriber.instances = []
+
+    with patch("voxcpm.server.app.PromptTranscriber", DummyTranscriber), _patch_model_loading():
+        app = server_app.create_app(settings)
+        with TestClient(app) as client:
+            response = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": settings.openai_model_name,
+                    "voice": "myvoice",
+                    "input": "Hello there",
+                    "response_format": "pcm",
+                },
+            )
+
+    assert response.status_code == 200
+    assert DummyTranscriber.instances
+    assert DummyTranscriber.instances[0].calls
+
+
+def test_voice_prompt_requires_text_when_asr_disabled(tmp_path):
+    voice_wav = tmp_path / "voice.wav"
+    voice_wav.write_bytes(b"fake")
+
+    settings = ServerSettings(voices_dir=str(tmp_path), enable_prompt_asr=False)
+    DummyTranscriber.instances = []
+
+    with _patch_model_loading():
+        app = server_app.create_app(settings)
+        with TestClient(app) as client:
+            response = client.post(
+                "/v1/audio/speech",
+                json={
+                    "model": settings.openai_model_name,
+                    "voice": "voice",
+                    "input": "Testing",
+                    "response_format": "pcm",
+                },
+            )
+
+    assert response.status_code == 400
+    assert "requires an accompanying transcript" in response.json()["error"]["message"]


### PR DESCRIPTION
## Summary
- add a reusable prompt transcriber that lazily loads SenseVoice to generate missing transcripts for voice presets
- wire the transcriber into the API server so preset voices and inline prompts without text are handled automatically when ASR is enabled
- expose configuration toggles for the ASR helper and cover the workflow with regression tests

## Testing
- pytest tests/test_audio_endpoint.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d04b0de030832b829882eb266a0f5f