### PR TITLE
Persist API audio responses as WAV and tune defaults

### DIFF
--- a/src/voxcpm/server/config.py
+++ b/src/voxcpm/server/config.py
@@ -65,6 +65,7 @@ class ServerSettings:
 
     voices_dir: Path
     default_voice: str
+    output_dir: Path
 
     stream_chunk_size: int
     allow_streaming: bool
@@ -109,6 +110,12 @@ class ServerSettings:
             self.voices_dir = _default_voices_dir()
         self.default_voice = str(overrides.get("default_voice") or env.get("VOXCPM_DEFAULT_VOICE") or "default")
 
+        output_dir_value = overrides.get("output_dir") or env.get("VOXCPM_OUTPUT_DIR")
+        if output_dir_value:
+            self.output_dir = Path(str(output_dir_value)).expanduser().resolve()
+        else:
+            self.output_dir = (Path.cwd() / "output").resolve()
+
         self.stream_chunk_size = _coerce_int(
             overrides.get("stream_chunk_size") or env.get("VOXCPM_STREAM_CHUNK_SIZE"), 32768
         )
@@ -116,7 +123,7 @@ class ServerSettings:
 
         self.inference_cfg_value = _coerce_float(overrides.get("inference_cfg_value") or env.get("VOXCPM_CFG_VALUE"), 2.0)
         self.inference_timesteps = _coerce_int(
-            overrides.get("inference_timesteps") or env.get("VOXCPM_INFERENCE_TIMESTEPS"), 10
+            overrides.get("inference_timesteps") or env.get("VOXCPM_INFERENCE_TIMESTEPS"), 16
         )
         self.max_length = _coerce_int(overrides.get("max_length") or env.get("VOXCPM_MAX_LENGTH"), 4096)
         self.normalize_text = _coerce_bool(overrides.get("normalize_text") or env.get("VOXCPM_NORMALIZE_TEXT"), True)

--- a/tests/test_audio_endpoint.py
+++ b/tests/test_audio_endpoint.py
@@ -41,7 +41,7 @@ def test_voice_prompt_auto_transcription(tmp_path):
     voice_wav = tmp_path / "myvoice.wav"
     voice_wav.write_bytes(b"fake")
 
-    settings = ServerSettings(voices_dir=str(tmp_path))
+    settings = ServerSettings(voices_dir=str(tmp_path), output_dir=str(tmp_path / "generated"))
     DummyTranscriber.instances = []
 
     with patch("voxcpm.server.app.PromptTranscriber", DummyTranscriber), _patch_model_loading():
@@ -57,7 +57,9 @@ def test_voice_prompt_auto_transcription(tmp_path):
                 },
             )
 
-    assert response.status_code == 200
+            assert response.status_code == 200
+            saved_files = list(settings.output_dir.glob("*.wav"))
+            assert saved_files
     assert DummyTranscriber.instances
     assert DummyTranscriber.instances[0].calls
 
@@ -66,7 +68,9 @@ def test_voice_prompt_requires_text_when_asr_disabled(tmp_path):
     voice_wav = tmp_path / "voice.wav"
     voice_wav.write_bytes(b"fake")
 
-    settings = ServerSettings(voices_dir=str(tmp_path), enable_prompt_asr=False)
+    settings = ServerSettings(
+        voices_dir=str(tmp_path), enable_prompt_asr=False, output_dir=str(tmp_path / "generated")
+    )
     DummyTranscriber.instances = []
 
     with _patch_model_loading():


### PR DESCRIPTION
## Summary
- persist every synthesized response from the API server as a WAV file under a configurable output directory that defaults to `./output`
- raise the server's default inference timesteps to 16 to prioritize higher quality speech
- extend the audio endpoint tests to cover file persistence behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0538b0a5c832b8a9ef16e968c5c86